### PR TITLE
Add highlight.scm

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -35,7 +35,7 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
         "cuh"
       ],
       "highlights": [
+        "queries/highlights.scm",
+        "node_modules/tree-sitter-c/queries/highlights.scm",
+        "node_modules/tree-sitter-cpp/queries/highlights.scm"
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/theHamsta/tree-sitter-cuda.git"
+    "url": "git://github.com/tree-sitter-grammars/tree-sitter-cuda.git"
   },
   "tree-sitter": [
     {
@@ -54,8 +54,6 @@
         "cuh"
       ],
       "highlights": [
-        "queries/highlights.scm",
-        "node_modules/tree-sitter-c/queries/highlights.scm"
       ]
     }
   ]

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,17 @@
+; inherits: cpp
+
+[
+  "<<<"
+  ">>>"
+] @punctuation.bracket
+
+[
+  "__host__"
+  "__device__"
+  "__global__"
+  "__managed__"
+  "__forceinline__"
+  "__noinline__"
+] @keyword.modifier
+
+"__launch_bounds__" @keyword.modifier


### PR DESCRIPTION
@clason does `tree-sitter highlight` have any documented guidelines for upstream queries? I tried to follow tree-sitter-cpp, tree-sitter-c. locals.scm/injection.scm could be added following nvim-treesitter

Rust crate needs update for the query constants

Fixes #91