### PR TITLE
fix(grammar)!: regenerate with cpp v0.23.0

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,8 +1,6 @@
 {
-  "0": "c",
-  "1": "p",
-  "2": "p",
   "name": "cuda",
+  "inherits": "cpp",
   "word": "identifier",
   "rules": {
     "translation_unit": {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,6 +47,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {


### PR DESCRIPTION
Breaking change: `(virtual)` is now anonymous `"virtual"`
